### PR TITLE
Fix resource name SqlConfiguration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -220,7 +220,7 @@
 - name: Adjust Max Server Memory to {{ mssql_max_server_memory }}
   when: mssql_max_server_memory is defined
   win_dsc:
-    resource_name: SqlServerConfiguration 
+    resource_name: SqlConfiguration
     InstanceName: "{{ mssql_instance_name }}"
     ServerName: "{{ ansible_hostname }}"
     OptionName: max server memory (MB)
@@ -231,7 +231,7 @@
 - name: Adjust Min Server Memory to {{ mssql_min_server_memory }}
   when: mssql_min_server_memory is defined
   win_dsc:
-    resource_name: SqlServerConfiguration 
+    resource_name: SqlConfiguration
     ServerName: "{{ ansible_hostname }}"
     InstanceName: "{{ mssql_instance_name }}"
     OptionName: min server memory (MB)
@@ -241,7 +241,7 @@
 - name: Adjust Max Degree of Parallelism
   when: mssql_max_degree_of_parallelism is defined
   win_dsc:
-    resource_name: SqlServerConfiguration 
+    resource_name: SqlConfiguration
     ServerName: "{{ ansible_hostname }}"
     InstanceName: "{{ mssql_instance_name }}"
     OptionName: max degree of parallelism


### PR DESCRIPTION
SqlServerConfiguration was renamed to SqlConfiguration. Source:
https://github.com/dsccommunity/SqlServerDsc/issues/1540