### PR TITLE
Avoid multiple downloads

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,6 +105,7 @@
   win_get_url:
     url: "{{ mssql_installation_source }}"
     dest: "{{ mssql_temp_download_path }}\\SQLServer2017-SSEI-Dev.exe"
+    force: false
 
 - name: Use Media Downloader to fetch SQL Installation CABs to {{ mssql_installation_path }}
   win_shell: "{{ mssql_temp_download_path }}\\SQLServer2017-SSEI-Dev.exe /Action=Download /MediaPath={{ mssql_installation_path }} /MediaType=CAB /Quiet"


### PR DESCRIPTION
win_get_url has 'force' attribute set to 'true' by default. It forces redownload of url every time.